### PR TITLE
[Benchmark]: Fixed & optimized BogoMIPS calculation on Motorola SLVR L7e

### DIFF
--- a/Benchmark/Benchmark.c
+++ b/Benchmark/Benchmark.c
@@ -553,12 +553,7 @@ static UINT32 HandleEventTimerExpired(EVENT_STACK_T *ev_st, APPLICATION_T *app) 
 				case APP_MENU_ITEM_BENCH_CPU:
 					app_instance->view = APP_VIEW_CPU_RESULTS;
 
-#if defined(FTR_L7E)
-					u_strcpy(app_instance->cpu_result.bogo_time, L"Error: L7e");
-					u_strcpy(app_instance->cpu_result.bogo_mips, L"Error: L7e");
-#else
 					BogoMIPS(&app_instance->cpu_result);
-#endif
 					Dhrystone(&app_instance->cpu_result);
 
 					break;

--- a/Benchmark/Benchmark.h
+++ b/Benchmark/Benchmark.h
@@ -29,6 +29,7 @@ typedef struct {
 } BENCHMARK_RESULTS_CPU_T;
 
 extern void delay_bmips(UINT32 loops);
+extern void delay_bmips_l7e(UINT32 loops);
 
 extern UINT32 BogoMIPS(BENCHMARK_RESULTS_CPU_T *result);
 

--- a/Benchmark/Makefile
+++ b/Benchmark/Makefile
@@ -15,7 +15,7 @@ LIB_PATH = $(ARM_PATH)/lib
 LIB_MAIN = Lib.o
 
 # Defines.
-DEFINES = -D__P2K__ -DEP1 -DLINUX_BOGOMIPS
+DEFINES = -D__P2K__ -DEP1 -DLINUX_BOGOMIPS -DFTR_L7E
 #DEFINES = -D__P2K__ -DEP1 -DLINUX_BOGOMIPS -DNO_ASM
 #DEFINES = -D__P2K__ -DEP1 -DPALMOS_BOGOMIPS
 #DEFINES = -D__P2K__ -DEP1 -DLINUX_BOGOMIPS -DFTR_V600
@@ -27,6 +27,7 @@ ELF_NAME = Benchmark
 
 all:
 	$(ARM_PATH)/bin/armasm -32 -bi -apcs /interwork delay_armv4t_ADS.S delay_armv4t_ADS.o
+	$(ARM_PATH)/bin/armasm -16 -bi -apcs /interwork  -apcs /interwork delay_l7e.S -o delay_l7e.o
 	$(ARM_PATH)/bin/tcc -I$(SDK_PATH) $(DEFINES) -bigend -apcs /interwork -O2 -c dhry_1.c -o dhry_1.o
 	$(ARM_PATH)/bin/tcc -I$(SDK_PATH) $(DEFINES) -bigend -apcs /interwork -O2 -c dhry_2.c -o dhry_2.o
 	$(ARM_PATH)/bin/tcc -I$(SDK_PATH) $(DEFINES) -bigend -apcs /interwork -O2 -c Phases.c -o Phases.o
@@ -34,7 +35,7 @@ all:
 	$(ARM_PATH)/bin/tcc -I$(SDK_PATH) $(DEFINES) -bigend -apcs /interwork -O2 -c $(ELF_NAME).c -o $(ELF_NAME).o
 
 	$(ARM_PATH)/bin/armlink -nolocals -reloc -first $(LIB_MAIN)\(Lib\) \
-		delay_armv4t_ADS.o dhry_1.o dhry_2.o Phases.o FireEffect.o $(ELF_NAME).o \
+		delay_armv4t_ADS.o dhry_1.o dhry_2.o delay_l7e.o Phases.o FireEffect.o $(ELF_NAME).o \
 		$(LIB_PATH)/$(LIB_MAIN) -o $(ELF_NAME).elf
 
 clean:

--- a/Benchmark/Phases.c
+++ b/Benchmark/Phases.c
@@ -115,7 +115,11 @@ UINT32 BogoMIPS(BENCHMARK_RESULTS_CPU_T *result) {
 
 		delta_a = suPalReadTime();
 
-		delay_bmips(loops_per_sec);
+        #ifdef FTR_L7E
+			delay_bmips_l7e(loops_per_sec);
+		#else
+			delay_bmips(loops_per_sec);
+    	#endif
 
 		delta_b = suPalReadTime();
 

--- a/Benchmark/delay_l7e.S
+++ b/Benchmark/delay_l7e.S
@@ -1,0 +1,16 @@
+
+	AREA |asm.delay_bmips_l7e|, CODE, READONLY
+	CODE16
+	EXPORT delay_bmips_l7e
+
+delay_bmips_l7e
+    push {r1-r2}
+    ldr r2, =0x3FC0000 ;just unused instruction, for ignore watchdog's(?) reboot...
+loop
+    ldrb r1, [r2] ;same as ldr
+    subs r0, r0, #1
+    bge loop
+    pop {r1-r2}
+	bx       lr
+
+    END


### PR DESCRIPTION
Fix L7e BogoMIPS calculation with unused instruction